### PR TITLE
Bug/dynamic concat path

### DIFF
--- a/lib/cfpathcheck.js
+++ b/lib/cfpathcheck.js
@@ -216,11 +216,15 @@ function checkFile(filePath) {
 		cfIncludeMatches.concat(includeMatches).forEach(function (includeMatch) {
 			// console.log(includeMatch);
 
-			// Dynamic path (contains #): all we can check is the non-dynamic part
+			// Dynamic path (contains # or &): all we can check is the non-dynamic part,
+			// wound back to the last slash
 			var templatePath = includeMatch[1];
 			var hashPos = templatePath.indexOf('#');
-			if (hashPos !== -1) {
-				templatePath = path.dirname(templatePath.substr(0, hashPos));
+			var ampersandPos = templatePath.indexOf('&');
+			if (hashPos !== -1 || ampersandPos !== -1) {
+				var searchPos = hashPos !== -1 ? hashPos : ampersandPos;
+				var lastSlashPos = templatePath.lastIndexOf('/', searchPos);
+				templatePath = path.dirname(templatePath.substr(0, lastSlashPos));
 			}
 
 			// Can't work with webroot-virtual paths, e.g. /missing.cfm

--- a/lib/cfpathcheck.js
+++ b/lib/cfpathcheck.js
@@ -211,7 +211,7 @@ function checkFile(filePath) {
 		var cfIncludeMatches = matchAll(line, /template=\"([^"]+)\"/g);
 
 		// include '$path'; (inside <cfscript>)
-		var includeMatches = matchAll(line, /\binclude\s['"]([^'"]+)['"]/g);
+		var includeMatches = matchAll(line, /\binclude\s['"](.*\.cfm)['"]/g);
 
 		cfIncludeMatches.concat(includeMatches).forEach(function (includeMatch) {
 			// console.log(includeMatch);


### PR DESCRIPTION
* Supports dynamic paths built using concatenation (`&`) rather than variable interpolation (`#`).
* Winds back to last slash in dynamic paths, no matter how they're built.