### PR TITLE
Chore npm updates 20180423

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1628,14 +1628,14 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.0.tgz",
-      "integrity": "sha512-Qj4dMF1N/wRALO1IRvnchn8c1i0awgrztrGx7MjF9ewDwlW/heNB+WeZ09bhp8Yp0TD+BZcADP8BRya0wmropA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
       "dev": true,
       "requires": {
         "ignore": "3.3.7",
         "minimatch": "3.0.4",
-        "resolve": "1.5.0",
+        "resolve": "1.7.1",
         "semver": "5.5.0"
       },
       "dependencies": {
@@ -1665,19 +1665,13 @@
           }
         },
         "resolve": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
           }
-        },
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,13 +1621,22 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.4.1.tgz",
-      "integrity": "sha512-HJ3kowJgZHk+lL6IPdzs2BV+lJAOfxtyW4OOCaHrOs0AJYdbb9orQKpR8w8YUuztW69QDiUYaGA8sLKFfGvWlQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.6.3.tgz",
+      "integrity": "sha512-99SddzRNkyQFhx8Du8M3ex/jG0MmuNu01gIb4iN+nNswYy8bKrwHnRRRQOcsBMFBIUArKAdU6BSI9OeLhYZl1w==",
       "dev": true,
       "requires": {
         "comment-parser": "0.4.2",
+        "jsdoctypeparser": "2.0.0-alpha-8",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "jsdoctypeparser": {
+          "version": "2.0.0-alpha-8",
+          "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz",
+          "integrity": "sha1-uvE3+44qVYgQrc8Z0tKi9oDpCl8=",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6304,9 +6304,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
+      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
       "dev": true
     },
     "pretty-remarkable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,13 +163,13 @@
       }
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "api-toc": {
@@ -181,26 +181,17 @@
         "code-context": "0.5.3",
         "filter-object": "2.1.0",
         "markdown-utils": "0.7.3",
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "relative": "3.0.2"
       }
     },
     "argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "underscore": "1.7.0",
-        "underscore.string": "2.4.0"
-      },
-      "dependencies": {
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-          "dev": true
-        }
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
       }
     },
     "arr-diff": {
@@ -218,7 +209,7 @@
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "requires": {
-        "make-iterator": "1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-flatten": {
@@ -231,7 +222,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-pluck": {
@@ -333,14 +324,22 @@
       "dev": true
     },
     "assign-deep": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-0.4.5.tgz",
-      "integrity": "sha1-18dsqhIwIBFPVQxm8II8VZ85rxM=",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-0.4.7.tgz",
+      "integrity": "sha512-tYlXoIH6RM2rclkx9uLXDKPKrDGsnxoWHE2J5+9tq2StAXeAAo8hLPZtOqwt22p8r6H5hnMgd8Oz8qPJl3W31g==",
       "dev": true,
       "requires": {
         "assign-symbols": "0.1.1",
         "is-primitive": "2.0.0",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "assign-symbols": {
@@ -361,15 +360,23 @@
       "dev": true
     },
     "async-done": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.2.2.tgz",
-      "integrity": "sha1-ukKA2lWhbhX0u4vzqESpGHh0DjE=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.2.4.tgz",
+      "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "next-tick": "1.0.0",
+        "end-of-stream": "1.4.1",
         "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-        "stream-exhaust": "1.0.1"
+        "process-nextick-args": "1.0.7",
+        "stream-exhaust": "1.0.2"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
       }
     },
     "async-each": {
@@ -415,17 +422,25 @@
       "integrity": "sha1-rEU7BVm0NwVJLoL5fmwG0Luez+M=",
       "dev": true,
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        "async": "0.9.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
       }
     },
     "async-listener": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.7.tgz",
-      "integrity": "sha512-6Bmzy9dHE1WWZdru7teS6kecmOy42cCzumQOn57vHa/49kjPMExdPLozDvr25J0hbQf5wMwFitJKnO7O3eqh2A==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
+      "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
       "dev": true,
       "requires": {
         "semver": "5.5.0",
-        "shimmer": "1.1.0"
+        "shimmer": "1.2.0"
       }
     },
     "async-settle": {
@@ -446,7 +461,7 @@
             "end-of-stream": "0.1.5",
             "next-tick": "0.2.2",
             "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "stream-exhaust": "1.0.1"
+            "stream-exhaust": "1.0.2"
           }
         },
         "end-of-stream": {
@@ -457,12 +472,6 @@
           "requires": {
             "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
           }
-        },
-        "next-tick": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-          "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0=",
-          "dev": true
         }
       }
     },
@@ -523,7 +532,7 @@
       "integrity": "sha1-TewEtAGlDjNsEirNfTo5ye/OOdk=",
       "dev": true,
       "requires": {
-        "async-done": "1.2.2",
+        "async-done": "1.2.4",
         "async-settle": "0.2.1",
         "lodash": "3.10.1",
         "now-and-later": "0.0.6"
@@ -567,9 +576,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bl": {
@@ -741,9 +750,9 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.2.2",
         "glob-parent": "2.0.0",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
         "is-binary-path": "1.0.1",
@@ -764,7 +773,15 @@
       "integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
       "dev": true,
       "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+        "object-assign": "2.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        }
       }
     },
     "cli-cursor": {
@@ -783,9 +800,9 @@
       "dev": true
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
@@ -796,7 +813,7 @@
       "requires": {
         "for-own": "0.1.5",
         "is-plain-object": "0.1.0",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+        "kind-of": "0.1.2",
         "mixin-object": "0.1.1"
       },
       "dependencies": {
@@ -804,6 +821,12 @@
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-0.1.0.tgz",
           "integrity": "sha1-PKfbAi3nL9EgB/GVe+tZ6llrl5w=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-0.1.2.tgz",
+          "integrity": "sha1-B71gHMlDP115vV7dIDHtFV8GBKQ=",
           "dev": true
         }
       }
@@ -857,6 +880,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
@@ -914,8 +943,16 @@
         "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
         "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.2.7",
         "session-cache": "0.2.0"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "computed-property": {
@@ -924,9 +961,26 @@
       "integrity": "sha512-ep+qu1T9PCwoGyZna2km59N4QqAuAB8+7m6whca42Idz3tmWkANHI3pGcE6qsxWLV27iWS1U3H+BSq0PpQMcnw==",
       "dev": true,
       "requires": {
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "0.3.2",
         "lodash.clonedeep": "3.0.1",
         "set-object": "0.1.0"
+      },
+      "dependencies": {
+        "get-value": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-0.3.2.tgz",
+          "integrity": "sha1-1S55M1XudeS4sE3sviozCULMyEU=",
+          "dev": true,
+          "requires": {
+            "isobject": "0.2.0"
+          }
+        },
+        "isobject": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+          "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
+          "dev": true
+        }
       }
     },
     "concat-map": {
@@ -970,27 +1024,72 @@
       "dev": true,
       "requires": {
         "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "arr-union": "2.1.0",
         "array-rest": "0.1.1",
         "class-extend": "0.1.2",
         "clone-deep": "0.1.1",
         "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
         "expander": "0.3.3",
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "extend-shallow": "1.1.4",
         "for-in": "0.1.8",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "has-own-deep": "0.1.4",
         "has-value": "0.2.1",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+        "kind-of": "1.1.0",
         "object.omit": "1.1.0",
         "plasma": "0.8.4",
-        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz"
+        "set-value": "0.1.6"
       },
       "dependencies": {
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
         "for-in": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
           "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
+        },
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         },
         "object.omit": {
@@ -1000,7 +1099,17 @@
           "dev": true,
           "requires": {
             "for-own": "0.1.5",
-            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+            "isobject": "1.0.2"
+          }
+        },
+        "set-value": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.1.6.tgz",
+          "integrity": "sha1-30GK1Ip5e0+s6tn3i2j+HQ/eVaE=",
+          "dev": true,
+          "requires": {
+            "isobject": "1.0.2",
+            "noncharacters": "1.1.0"
           }
         }
       }
@@ -1021,13 +1130,13 @@
       }
     },
     "continuation-local-storage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.0.tgz",
-      "integrity": "sha1-4Z/Da1lwkKXU5KOy6j68XilpSiQ=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "dev": true,
       "requires": {
-        "async-listener": "0.6.7",
-        "emitter-listener": "1.0.1"
+        "async-listener": "0.6.9",
+        "emitter-listener": "1.1.1"
       }
     },
     "copyright-regex": {
@@ -1084,8 +1193,16 @@
       "integrity": "sha1-t561Snjy11rGAPvgD9jRx+nj2/U=",
       "dev": true,
       "requires": {
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.2.7",
         "look-up": "0.8.3"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "dashdash": {
@@ -1118,33 +1235,92 @@
         "collection-visit": "0.1.1",
         "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
         "has-own-deep": "0.1.4",
         "has-value": "0.2.1",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "object.omit": "2.0.1",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-        "union-value": "https://registry.npmjs.org/union-value/-/union-value-0.2.3.tgz"
+        "rimraf": "2.6.2",
+        "set-value": "0.2.0",
+        "union-value": "0.1.1"
+      },
+      "dependencies": {
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+          }
+        },
+        "set-value": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
+          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
+          "dev": true,
+          "requires": {
+            "isobject": "1.0.2",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "union-value": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.1.1.tgz",
+          "integrity": "sha1-aSDlkH7uK/8Rt8f7CYuIi/p8xU8=",
+          "dev": true,
+          "requires": {
+            "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "get-value": "1.3.1",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "set-value": "0.2.0"
+          }
+        }
       }
     },
     "date.js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
-      "integrity": "sha1-OefHx3rcdl0Qvs9JbKzTkTMtfMg=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
+      "integrity": "sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==",
       "dev": true,
       "requires": {
-        "debug": "0.7.4",
-        "lodash.filter": "4.6.0",
-        "lodash.findkey": "4.6.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.includes": "4.3.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.partition": "4.6.0",
-        "lodash.trim": "4.5.1"
+        "debug": "3.1.0"
       }
     },
     "dateformat": {
@@ -1158,10 +1334,13 @@
       }
     },
     "debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1187,7 +1366,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2"
+        "clone": "1.0.4"
       }
     },
     "define-property": {
@@ -1223,7 +1402,24 @@
       "integrity": "sha1-Y4XK4UAE28DBzY3//+uGPVGZnv8=",
       "dev": true,
       "requires": {
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
       }
     },
     "diff": {
@@ -1282,30 +1478,33 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        }
       }
     },
     "duplexify": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-      "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.0.0",
+        "end-of-stream": "1.4.1",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-          "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-          "dev": true,
-          "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-          }
-        }
       }
     },
     "ecc-jsbn": {
@@ -1318,20 +1517,12 @@
       }
     },
     "emitter-listener": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
-      "integrity": "sha1-skmepuWCMKUsJo1d8mHuzZ8Q/pc=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.1.tgz",
+      "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
       "dev": true,
       "requires": {
-        "shimmer": "1.0.0"
-      },
-      "dependencies": {
-        "shimmer": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
-          "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk=",
-          "dev": true
-        }
+        "shimmer": "1.2.0"
       }
     },
     "en-route": {
@@ -1342,30 +1533,47 @@
       "requires": {
         "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
         "array-slice": "0.2.3",
-        "debug": "2.6.8",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+        "debug": "2.6.9",
+        "kind-of": "1.1.0",
         "path-to-regexp": "1.7.0",
-        "utils-merge": "1.0.0"
+        "utils-merge": "1.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
         }
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+        "once": "1.4.0"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+          }
+        }
       }
     },
     "ends-with": {
@@ -1380,13 +1588,13 @@
       "integrity": "sha1-+H6MkLuAzT9YWXrFaVk+5G2idC0=",
       "dev": true,
       "requires": {
-        "assign-deep": "0.4.5",
+        "assign-deep": "0.4.7",
         "collection-visit": "0.2.3",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "get-value": "1.3.1",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
         "object.omit": "2.0.1",
-        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz"
+        "set-value": "0.2.0"
       },
       "dependencies": {
         "collection-visit": {
@@ -1395,10 +1603,48 @@
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "dev": true,
           "requires": {
-            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+            "lazy-cache": "2.0.2",
             "map-visit": "0.1.5",
             "object-visit": "0.3.4"
+          },
+          "dependencies": {
+            "lazy-cache": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+              "dev": true,
+              "requires": {
+                "set-getter": "0.1.0"
+              }
+            }
           }
+        },
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
         },
         "object-visit": {
           "version": "0.3.4",
@@ -1407,6 +1653,24 @@
           "dev": true,
           "requires": {
             "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+          }
+        },
+        "set-value": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
+          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
+          "dev": true,
+          "requires": {
+            "isobject": "1.0.2",
+            "noncharacters": "1.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+              "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
+              "dev": true
+            }
           }
         }
       }
@@ -1419,8 +1683,25 @@
       "requires": {
         "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
         "async-helpers": "0.2.5",
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "extend-shallow": "1.1.4",
         "helper-cache": "0.7.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
       }
     },
     "engine-lodash": {
@@ -1432,10 +1713,16 @@
         "ansi-red": "0.1.1",
         "delimiter-regex": "1.3.1",
         "engine-utils": "0.1.1",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.2.7",
         "lodash": "3.10.1"
       },
       "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -1761,7 +2048,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -1921,28 +2208,14 @@
       }
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-          }
-        }
       }
     },
     "fast-deep-equal": {
@@ -1991,7 +2264,15 @@
       "dev": true,
       "requires": {
         "is-binary-buffer": "1.0.0",
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "filename-regex": {
@@ -2031,8 +2312,19 @@
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
         "filter-keys": "1.1.0",
         "filter-values": "0.4.1",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "object.pick": "1.2.0"
+        "kind-of": "2.0.1",
+        "object.pick": "1.3.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+          }
+        }
       }
     },
     "filter-values": {
@@ -2175,31 +2467,21 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.2.tgz",
+      "integrity": "sha512-iownA+hC4uHFp+7gwP/y5SzaiUo7m2vpa0dhpzw8YuKtiZsz7cIXsFbXpLEeBM6WuCQyw1MH4RRe6XI8GFUctQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.9.1"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -2207,7 +2489,7 @@
           "dev": true
         },
         "aproba": {
-          "version": "1.1.1",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2219,91 +2501,25 @@
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "readable-stream": "2.3.6"
           }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
-        "caseless": {
-          "version": "0.12.0",
+        "brace-expansion": {
+          "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2312,14 +2528,6 @@
           "version": "1.1.0",
           "bundled": true,
           "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2334,36 +2542,11 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
+          "optional": true
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2377,80 +2560,32 @@
           "dev": true,
           "optional": true
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "optional": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
+        "detect-libc": {
+          "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
         },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
           "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
@@ -2458,7 +2593,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
+            "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
             "has-unicode": "2.0.1",
             "object-assign": "4.1.1",
@@ -2468,27 +2603,11 @@
             "wide-align": "1.1.2"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -2498,65 +2617,35 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
-        "hawk": {
-          "version": "3.1.3",
+        "iconv-lite": {
+          "version": "0.4.21",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "safer-buffer": "2.1.2"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -2568,7 +2657,7 @@
           "dev": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2581,110 +2670,42 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
           "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -2700,21 +2721,33 @@
           "dev": true,
           "optional": true
         },
-        "node-pre-gyp": {
-          "version": "0.6.36",
+        "needle": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.9.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
+            "needle": "2.2.0",
             "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -2723,12 +2756,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
-          "version": "4.1.0",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2743,12 +2792,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2777,7 +2820,7 @@
           "optional": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2789,39 +2832,23 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.2.1",
+          "version": "1.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
-            "ini": "1.3.4",
+            "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
           },
@@ -2835,64 +2862,48 @@
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
+          "version": "2.3.6",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
-          "version": "5.0.1",
+          "version": "5.1.1",
           "bundled": true,
           "dev": true
         },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.5.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2909,40 +2920,6 @@
           "dev": true,
           "optional": true
         },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2954,18 +2931,13 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "5.1.1"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -2982,80 +2954,25 @@
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
+          "version": "4.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
         },
         "wide-align": {
           "version": "1.1.2",
@@ -3068,6 +2985,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
           "bundled": true,
           "dev": true
         }
@@ -3120,8 +3042,16 @@
         "ansi-red": "0.1.1",
         "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
         "filter-object": "2.1.0",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.2.7",
         "min-request": "1.4.1"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "get-stdin": {
@@ -3160,16 +3090,16 @@
       "dev": true
     },
     "git-user-name": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/git-user-name/-/git-user-name-1.2.0.tgz",
-      "integrity": "sha1-83phhLAS9b6TEBYwa0x7e4av/yQ=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/git-user-name/-/git-user-name-1.2.1.tgz",
+      "integrity": "sha512-t4IfqsTJdXWFVur0P9VCqhMpwmI6XnMR7haKikObCPytyabVfhyR6NthNa6ximq4nQjBF31h0qBCyvpT6gObEQ==",
       "dev": true,
       "requires": {
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
         "git-config-path": "0.1.0",
         "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
         "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-        "parse-git-config": "0.4.3"
+        "parse-git-config": "1.1.1"
       }
     },
     "github": {
@@ -3238,21 +3168,54 @@
       "integrity": "sha1-uELfENaIx+trz869hG84UilrMgA=",
       "dev": true,
       "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "glob": "4.5.3",
         "glob2base": "0.0.12",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+        "minimatch": "2.0.10",
         "ordered-read-streams": "0.1.0",
         "through2": "0.6.5",
         "unique-stream": "2.2.1"
       },
       "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "minimatch": "2.0.10",
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
+            "readable-stream": "1.0.34",
             "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
@@ -3365,7 +3328,7 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "is-windows": "0.2.0",
         "which": "1.2.14"
       }
@@ -3396,23 +3359,62 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "glob": "3.1.21",
         "lodash": "1.0.2",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+        "minimatch": "0.2.14"
       },
       "dependencies": {
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        },
         "lodash": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         }
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
         "sparkles": "1.0.0"
@@ -3458,19 +3460,10 @@
         "ansi-red": "0.1.1",
         "coffee-script": "1.12.7",
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-        "js-yaml": "3.10.0",
-        "toml": "2.3.2"
+        "js-yaml": "3.11.0",
+        "toml": "2.3.3"
       },
       "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-          }
-        },
         "coffee-script": {
           "version": "1.12.7",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
@@ -3484,9 +3477,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
             "argparse": "1.0.10",
@@ -3678,18 +3671,36 @@
       "dev": true,
       "requires": {
         "get-first": "0.1.2",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+        "kind-of": "1.1.0",
         "micromatch": "2.3.11",
         "through2": "0.6.5"
       },
       "dependencies": {
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
+            "readable-stream": "1.0.34",
             "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
@@ -3706,7 +3717,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "2.2.0",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3715,7 +3726,7 @@
         "lodash.template": "3.6.2",
         "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
         "multipipe": "0.1.2",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
         "through2": "2.0.3",
         "vinyl": "0.5.3"
@@ -3739,6 +3750,12 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
           "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
           "dev": true
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
         }
       }
     },
@@ -3748,7 +3765,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "har-validator": {
@@ -3812,8 +3829,14 @@
           "integrity": "sha1-/191LbccMyiv1eaF62rd3T6v+rc=",
           "dev": true,
           "requires": {
-            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+            "isobject": "0.2.0"
           }
+        },
+        "isobject": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+          "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
+          "dev": true
         }
       }
     },
@@ -3880,8 +3903,16 @@
       "dev": true,
       "requires": {
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.2.7",
         "lodash.bind": "3.1.0"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "helper-changelog": {
@@ -3890,7 +3921,7 @@
       "integrity": "sha1-HJUtltifYmFeOdfM39zhsMo6LdU=",
       "dev": true,
       "requires": {
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "stringify-changelog": "0.1.6"
       }
     },
@@ -3901,7 +3932,7 @@
       "dev": true,
       "requires": {
         "api-toc": "0.3.2",
-        "mixin-deep": "1.2.0"
+        "mixin-deep": "1.3.1"
       }
     },
     "helper-copyright": {
@@ -3960,10 +3991,27 @@
       "integrity": "sha1-2HDKu6BB0ynMhW2yC7jElnTj7yg=",
       "dev": true,
       "requires": {
-        "date.js": "0.3.1",
+        "date.js": "0.3.3",
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "moment": "2.18.1"
+        "kind-of": "3.2.2",
+        "moment": "2.22.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "helper-license": {
@@ -3974,7 +4022,7 @@
       "requires": {
         "arr-pluck": "0.1.0",
         "markdown-utils": "0.6.1",
-        "mixin-deep": "1.2.0"
+        "mixin-deep": "1.3.1"
       },
       "dependencies": {
         "is-number": {
@@ -4018,7 +4066,7 @@
         "ansi-red": "0.1.1",
         "async-array-reduce": "0.1.0",
         "get-pkgs": "0.2.3",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.2.7",
         "load-pkg": "1.3.0",
         "markdown-utils": "0.7.3",
         "parse-github-url": "0.2.1",
@@ -4030,6 +4078,12 @@
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.1.0.tgz",
           "integrity": "sha1-x0uIZR1cf0bOUgPRUMPMfu3KV/I=",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         },
         "parse-github-url": {
@@ -4053,7 +4107,7 @@
         "async-array-reduce": "0.1.0",
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
         "get-pkgs": "0.2.3",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "success-symbol": "0.1.0"
       },
       "dependencies": {
@@ -4061,6 +4115,24 @@
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.1.0.tgz",
           "integrity": "sha1-x0uIZR1cf0bOUgPRUMPMfu3KV/I=",
+          "dev": true
+        },
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         }
       }
@@ -4101,7 +4173,7 @@
         "globby": "2.1.0",
         "markdown-toc": "0.11.9",
         "markdown-utils": "0.6.1",
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "relative": "3.0.2"
       },
       "dependencies": {
@@ -4247,9 +4319,9 @@
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "init-file-loader": {
@@ -4449,7 +4521,15 @@
       "integrity": "sha1-vGAxKQtly/eZudlQK1D9U3VSQAc=",
       "dev": true,
       "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+        "is-buffer": "1.1.6"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
       }
     },
     "is-binary-path": {
@@ -4458,7 +4538,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -4612,12 +4692,20 @@
       }
     },
     "is-plain-object": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz",
-      "integrity": "sha1-wVvz5LZrYtcu+vKSWEhmPsvGGbY=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "is-posix-bracket": {
@@ -4754,7 +4842,7 @@
       "integrity": "sha1-6N7hS3IDn+hxDVsWamyPJYGglDc=",
       "dev": true,
       "requires": {
-        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+        "arr-union": "2.1.0",
         "js-comments-template": "0.7.4",
         "lodash": "3.10.1",
         "logging-helpers": "0.4.0",
@@ -4763,6 +4851,12 @@
         "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
       },
       "dependencies": {
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -4844,11 +4938,12 @@
       "dev": true
     },
     "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+        "jsonify": "0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -4863,7 +4958,8 @@
       "dev": true
     },
     "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
@@ -4896,8 +4992,43 @@
       "dev": true,
       "requires": {
         "delimiter-regex": "1.3.1",
-        "falsey": "https://registry.npmjs.org/falsey/-/falsey-0.3.0.tgz",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz"
+        "falsey": "0.2.1",
+        "get-value": "1.3.1"
+      },
+      "dependencies": {
+        "falsey": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/falsey/-/falsey-0.2.1.tgz",
+          "integrity": "sha1-XvvOKAzRttQvkFXlMBBTrWgkObQ=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "lazy-cache": {
@@ -4927,11 +5058,11 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "has-value": "0.2.1",
         "log-symbols": "1.0.2",
         "rethrow": "0.1.0",
-        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz"
+        "set-value": "0.2.0"
       },
       "dependencies": {
         "chalk": {
@@ -4947,6 +5078,30 @@
             "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
           }
         },
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        },
         "log-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
@@ -4954,21 +5109,16 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-              }
-            }
+          }
+        },
+        "set-value": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
+          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
+          "dev": true,
+          "requires": {
+            "isobject": "1.0.2",
+            "noncharacters": "1.1.0"
           }
         }
       }
@@ -5046,11 +5196,11 @@
       "integrity": "sha1-Cm3gfxp5YlVrmva/KYRSCdqbxO8=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "has-any": "0.1.2",
         "has-any-deep": "0.3.2",
         "is-glob": "1.1.3",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+        "kind-of": "1.1.0",
         "lodash": "3.10.1",
         "map-files": "0.7.6",
         "omit-empty": "0.3.6",
@@ -5059,9 +5209,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5071,6 +5221,12 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
           "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         },
         "lodash": {
@@ -5087,10 +5243,24 @@
       "integrity": "sha1-dEv1wON/NP5FU+70KLwkiSbiCrs=",
       "dev": true,
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "async": "0.9.2",
         "bluebird": "2.11.0",
         "event-stream": "3.3.4",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+        "kind-of": "0.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-0.1.2.tgz",
+          "integrity": "sha1-B71gHMlDP115vV7dIDHtFV8GBKQ=",
+          "dev": true
+        }
       }
     },
     "lodash": {
@@ -5252,30 +5422,6 @@
         "lodash._root": "3.0.1"
       }
     },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
-      "dev": true
-    },
-    "lodash.findkey": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
-      "integrity": "sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg=",
-      "dev": true
-    },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
-      "dev": true
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-      "dev": true
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -5288,12 +5434,6 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
-      "dev": true
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -5304,12 +5444,6 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
-    },
-    "lodash.partition": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
-      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=",
-      "dev": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -5343,12 +5477,6 @@
         "lodash._reinterpolate": "3.0.0",
         "lodash.escape": "3.2.0"
       }
-    },
-    "lodash.trim": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
-      "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc=",
-      "dev": true
     },
     "log-events": {
       "version": "https://registry.npmjs.org/log-events/-/log-events-0.3.0.tgz",
@@ -5436,12 +5564,20 @@
       }
     },
     "make-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
-      "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "map-cache": {
@@ -5456,9 +5592,17 @@
       "integrity": "sha1-jEuZNaI6qwdV6wWYpmR5byO6vVQ=",
       "dev": true,
       "requires": {
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "1.0.4",
         "matched": "0.4.4",
         "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true
+        }
       }
     },
     "map-obj": {
@@ -5479,10 +5623,19 @@
       "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
       "dev": true,
       "requires": {
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "2.0.2",
         "object-visit": "0.3.4"
       },
       "dependencies": {
+        "lazy-cache": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+          "dev": true,
+          "requires": {
+            "set-getter": "0.1.0"
+          }
+        },
         "object-visit": {
           "version": "0.3.4",
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
@@ -5516,8 +5669,8 @@
         "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
         "markdown-link": "0.1.1",
         "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "mixin-deep": "1.2.0",
-        "object.pick": "1.2.0",
+        "mixin-deep": "1.3.1",
+        "object.pick": "1.3.0",
         "remarkable": "1.7.1",
         "repeat-string": "1.6.1"
       }
@@ -5552,8 +5705,19 @@
         "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
         "has-glob": "0.1.1",
         "is-valid-glob": "0.3.0",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "2.0.2",
         "resolve-dir": "0.1.1"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+          "dev": true,
+          "requires": {
+            "set-getter": "0.1.0"
+          }
+        }
       }
     },
     "meow": {
@@ -5581,7 +5745,7 @@
       "dev": true,
       "requires": {
         "clone-deep": "0.1.1",
-        "is-plain-object": "2.0.3"
+        "is-plain-object": "2.0.4"
       }
     },
     "merge-stream": {
@@ -5593,13 +5757,25 @@
         "through2": "0.6.5"
       },
       "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
+            "readable-stream": "1.0.34",
             "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
@@ -5623,7 +5799,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "middleware-utils": {
@@ -5634,7 +5810,15 @@
       "requires": {
         "ansi-red": "0.1.1",
         "ansi-yellow": "0.1.1",
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        "async": "0.9.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
       }
     },
     "mime": {
@@ -5679,13 +5863,24 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
-      "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
         "for-in": "1.0.2",
-        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "mixin-object": {
@@ -5713,9 +5908,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
       "dev": true
     },
     "ms": {
@@ -5751,11 +5946,17 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "dev": true,
       "optional": true
+    },
+    "natives": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
+      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5764,14 +5965,20 @@
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0=",
       "dev": true
     },
     "node-uuid": {
       "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+      "dev": true
+    },
+    "noncharacters": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz",
+      "integrity": "sha1-rzPfMP1Q7TxTzSAiWPJa2pC1QNI=",
       "dev": true
     },
     "nopt": {
@@ -5801,7 +6008,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "now-and-later": {
@@ -5835,7 +6042,15 @@
       "integrity": "sha1-sbtnSfIo7nbgxC84UdKKFNIzziY=",
       "dev": true,
       "requires": {
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+        "isobject": "1.0.2"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
+          "dev": true
+        }
       }
     },
     "object.omit": {
@@ -5849,12 +6064,20 @@
       }
     },
     "object.pick": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
-      "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "object.reduce": {
@@ -5901,13 +6124,69 @@
       "dev": true,
       "requires": {
         "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "has-value": "0.2.1",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-        "mixin-deep": "1.2.0",
-        "set-value": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.1.0",
+        "mixin-deep": "1.3.1",
+        "set-value": "0.2.0",
         "to-flags": "0.1.0"
+      },
+      "dependencies": {
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          },
+          "dependencies": {
+            "lazy-cache": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+              "dev": true
+            }
+          }
+        },
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.1.0.tgz",
+          "integrity": "sha1-1s1FAlHUFbcBA3ZfYxMKAEmgN5U=",
+          "dev": true,
+          "requires": {
+            "ansi-yellow": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
+          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
+          "dev": true,
+          "requires": {
+            "isobject": "1.0.2",
+            "noncharacters": "1.1.0"
+          }
+        }
       }
     },
     "optionator": {
@@ -6040,15 +6319,15 @@
       }
     },
     "parse-git-config": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.4.3.tgz",
-      "integrity": "sha1-Z9YiSN1aJOYFP4R1EF8fuelLuwA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "dev": true,
       "requires": {
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
         "fs-exists-sync": "0.1.0",
         "git-config-path": "1.0.1",
-        "ini": "1.3.4"
+        "ini": "1.3.5"
       },
       "dependencies": {
         "git-config-path": {
@@ -6109,18 +6388,69 @@
       "dev": true
     },
     "parser-front-matter": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/parser-front-matter/-/parser-front-matter-1.6.3.tgz",
-      "integrity": "sha1-aJoSRmUsgeR8Tq5z9rVzdhiBLew=",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/parser-front-matter/-/parser-front-matter-1.6.4.tgz",
+      "integrity": "sha512-eqtUnI5+COkf1CQOYo8FmykN5Zs+5Yr60f/7GcPgQDZEEjdE/VZ4WMaMo9g37foof8h64t/TH2Uvk2Sq0fDy/g==",
       "dev": true,
       "requires": {
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
         "file-is-binary": "1.0.0",
-        "gray-matter": "2.1.1",
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-        "mixin-deep": "1.2.0",
+        "gray-matter": "3.1.1",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2",
+        "mixin-deep": "1.3.1",
         "trim-leading-lines": "0.1.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "gray-matter": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
+          "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "js-yaml": "3.11.0",
+            "kind-of": "5.1.0",
+            "strip-bom-string": "1.0.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+          "dev": true,
+          "requires": {
+            "set-getter": "0.1.0"
+          }
+        }
       }
     },
     "path-exists": {
@@ -6183,7 +6513,7 @@
       "dev": true,
       "requires": {
         "array-slice": "0.2.3",
-        "object.pick": "1.2.0"
+        "object.pick": "1.3.0"
       }
     },
     "pify": {
@@ -6218,15 +6548,32 @@
       "integrity": "sha1-VELjO6m/W2zDVWouhVND2Mvfp3c=",
       "dev": true,
       "requires": {
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "extend-shallow": "1.1.4",
         "globby": "2.1.0",
         "is-glob": "2.0.1",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "mixin-deep": "1.2.0",
+        "kind-of": "2.0.1",
+        "mixin-deep": "1.3.1",
         "option-cache": "1.5.0",
         "relative": "3.0.2"
       },
       "dependencies": {
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+              "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+              "dev": true
+            }
+          }
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -6252,6 +6599,15 @@
             "object-assign": "3.0.0"
           }
         },
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+          }
+        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -6269,8 +6625,8 @@
         "ansi-cyan": "0.1.1",
         "ansi-red": "0.1.1",
         "arr-diff": "1.1.0",
-        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -6282,6 +6638,27 @@
             "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
             "array-slice": "0.2.3"
           }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
         }
       }
     },
@@ -6315,7 +6692,7 @@
       "integrity": "sha1-1yZLkFW+oTOXqaPoWitK0/o7ghg=",
       "dev": true,
       "requires": {
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "lazy-cache": "0.1.0",
         "list-item": "0.1.2",
         "markdown-utils": "0.7.3",
         "repeat-string": "1.6.1"
@@ -6326,6 +6703,15 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
           "integrity": "sha1-nYJAnzqKi+7PJJsbx9raSYKZZuQ=",
           "dev": true
+        },
+        "lazy-cache": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.1.0.tgz",
+          "integrity": "sha1-1s1FAlHUFbcBA3ZfYxMKAEmgN5U=",
+          "dev": true,
+          "requires": {
+            "ansi-yellow": "0.1.1"
+          }
         },
         "list-item": {
           "version": "0.1.2",
@@ -6363,16 +6749,42 @@
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+        "kind-of": "4.0.0"
       },
       "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6443,9 +6855,36 @@
       "dev": true,
       "requires": {
         "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+        "minimatch": "3.0.4",
         "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
       }
     },
     "readme-badges": {
@@ -6460,7 +6899,24 @@
       "integrity": "sha1-YHjO4wIEWTTOoDHAhm5f/ZN4D+I=",
       "dev": true,
       "requires": {
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -6483,13 +6939,12 @@
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpp": {
@@ -6647,12 +7102,30 @@
       "requires": {
         "argparse": "0.1.16",
         "autolinker": "0.15.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+          "dev": true,
+          "requires": {
+            "underscore": "1.7.0",
+            "underscore.string": "2.4.0"
+          }
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -6854,7 +7327,27 @@
       "integrity": "sha1-GI5Hv4BooNv6JMbdDggn6Zc85xc=",
       "dev": true,
       "requires": {
-        "continuation-local-storage": "3.2.0"
+        "continuation-local-storage": "3.2.1"
+      }
+    },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      },
+      "dependencies": {
+        "to-object-path": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "dev": true,
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+          }
+        }
       }
     },
     "set-immediate-shim": {
@@ -6869,11 +7362,26 @@
       "integrity": "sha1-pNtFQvA+dOk4RTtX3EgCMIpEtQI=",
       "dev": true,
       "requires": {
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+        "get-value": "0.3.2",
+        "isobject": "0.2.0",
         "preserve": "0.1.3"
       },
       "dependencies": {
+        "get-value": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-0.3.2.tgz",
+          "integrity": "sha1-1S55M1XudeS4sE3sviozCULMyEU=",
+          "dev": true,
+          "requires": {
+            "isobject": "0.2.0"
+          }
+        },
+        "isobject": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+          "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
+          "dev": true
+        },
         "preserve": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.1.3.tgz",
@@ -6912,9 +7420,9 @@
       "dev": true
     },
     "shimmer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
-      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag==",
       "dev": true
     },
     "should": {
@@ -6930,7 +7438,7 @@
     },
     "should-equal": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
       "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
       "dev": true,
       "requires": {
@@ -6950,6 +7458,12 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
       "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
@@ -7051,9 +7565,9 @@
       }
     },
     "stream-exhaust": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.1.tgz",
-      "integrity": "sha1-wMRFXlTOWhecqHNuczNLTn/WdVM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
       "dev": true
     },
     "stream-shift": {
@@ -7102,8 +7616,8 @@
       "requires": {
         "columnify": "1.5.4",
         "js-yaml-lite": "0.1.1",
-        "mixin-deep": "1.2.0",
-        "moment": "2.18.1"
+        "mixin-deep": "1.3.1",
+        "moment": "2.22.1"
       }
     },
     "stringify-github-url": {
@@ -7139,6 +7653,12 @@
       "requires": {
         "is-utf8": "0.2.1"
       }
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true
     },
     "strip-color": {
       "version": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
@@ -7197,33 +7717,39 @@
         "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
         "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
         "array-slice": "0.2.3",
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "async": "0.9.2",
         "chalk": "1.1.3",
         "clone-deep": "0.1.1",
         "config-cache": "4.0.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "en-route": "0.5.0",
         "engine-cache": "0.12.2",
         "export-files": "2.1.1",
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "extend-shallow": "1.1.4",
         "for-own": "0.1.5",
         "globby": "2.1.0",
         "has-value": "0.2.1",
         "helper-cache": "0.7.2",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+        "kind-of": "1.1.0",
         "layouts": "0.9.0",
         "load-templates": "0.7.3",
         "loader-cache": "0.4.0",
         "middleware-utils": "0.1.4",
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "object.reduce": "0.1.7",
         "option-cache": "1.5.0",
-        "parser-front-matter": "1.6.3",
+        "parser-front-matter": "1.6.4",
         "pick-from": "0.1.0",
         "relative": "3.0.2",
         "template-utils": "0.6.2"
       },
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -7238,12 +7764,21 @@
           }
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
           }
         },
         "glob": {
@@ -7266,10 +7801,24 @@
           "dev": true,
           "requires": {
             "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "async": "1.5.2",
             "glob": "5.0.15",
             "object-assign": "3.0.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            }
           }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
         },
         "object-assign": {
           "version": "3.0.0",
@@ -7295,7 +7844,7 @@
         "globby": "2.1.0",
         "is-glob": "1.1.3",
         "js-comments": "0.5.4",
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "relative": "3.0.2",
         "template-bind-helpers": "0.1.2"
       },
@@ -7349,18 +7898,47 @@
         "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
         "center-align": "0.1.3",
         "export-files": "2.1.1",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "is-number": "2.1.0",
-        "is-plain-object": "2.0.3",
+        "is-plain-object": "2.0.4",
         "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
         "object.omit": "2.0.1",
         "relative": "3.0.2",
         "right-align": "0.1.3",
         "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
         "to-gfm-code-block": "0.1.1",
         "word-wrap": "1.2.3"
+      },
+      "dependencies": {
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "template-toc": {
@@ -7369,8 +7947,25 @@
       "integrity": "sha1-NakVMh5ZLybZzJDZ5WXgDuz//HU=",
       "dev": true,
       "requires": {
-        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+        "extend-shallow": "1.1.4",
         "markdown-toc": "0.11.9"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
       }
     },
     "template-utils": {
@@ -7385,12 +7980,12 @@
         "export-files": "2.1.1",
         "extract-gfm": "0.1.0",
         "is-number": "2.1.0",
-        "is-plain-object": "2.0.3",
+        "is-plain-object": "2.0.4",
         "is-stream": "1.1.0",
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+        "isobject": "1.0.2",
         "load-templates": "0.7.3",
         "map-files": "0.7.6",
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "object.reduce": "0.1.7",
         "parse-gitignore": "0.1.2",
         "to-template": "0.1.2",
@@ -7415,6 +8010,12 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
           "dev": true
         },
         "parse-gitignore": {
@@ -7550,8 +8151,14 @@
           "integrity": "sha1-/191LbccMyiv1eaF62rd3T6v+rc=",
           "dev": true,
           "requires": {
-            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+            "isobject": "0.2.0"
           }
+        },
+        "isobject": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+          "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
+          "dev": true
         }
       }
     },
@@ -7561,7 +8168,7 @@
       "integrity": "sha1-7bVrtmT4YK3hdNmISraVQbd+RFM=",
       "dev": true,
       "requires": {
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+        "isobject": "1.0.2",
         "vinyl": "0.4.6"
       },
       "dependencies": {
@@ -7569,6 +8176,12 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
           "dev": true
         },
         "vinyl": {
@@ -7584,9 +8197,9 @@
       }
     },
     "toml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.2.tgz",
-      "integrity": "sha1-Xt7VykKIeSSUn9BusOlVZWAB6DQ=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
       "dev": true
     },
     "tough-cookie": {
@@ -7681,7 +8294,7 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "json-stable-stringify": "1.0.1",
         "through2-filter": "2.0.0"
       }
     },
@@ -7699,7 +8312,7 @@
         "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
         "leven": "2.1.0",
         "load-pkg": "3.0.1",
-        "mixin-deep": "1.2.0",
+        "mixin-deep": "1.3.1",
         "omit-empty": "0.3.6",
         "parse-author": "0.2.2",
         "parse-copyright": "0.4.0",
@@ -7742,9 +8355,9 @@
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -7785,9 +8398,9 @@
         "event-stream": "3.3.4",
         "export-files": "2.1.1",
         "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-        "get-value": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz",
+        "get-value": "1.3.1",
         "gfm-code-blocks": "0.3.0",
-        "git-user-name": "1.2.0",
+        "git-user-name": "1.2.1",
         "globby": "2.1.0",
         "gulp-drafts": "0.2.0",
         "gulp-util": "3.0.8",
@@ -7802,7 +8415,7 @@
         "helper-resolve": "0.3.1",
         "helper-toc": "0.2.0",
         "init-file-loader": "0.1.1",
-        "is-plain-object": "2.0.3",
+        "is-plain-object": "2.0.4",
         "is-true": "0.1.1",
         "js-comments": "0.5.4",
         "lint-templates": "0.1.2",
@@ -7818,7 +8431,7 @@
         "parse-filepath": "0.6.3",
         "parse-github-url": "0.1.1",
         "parse-gitignore": "0.2.0",
-        "parser-front-matter": "1.6.3",
+        "parser-front-matter": "1.6.4",
         "plugin-error": "0.1.2",
         "pretty-remarkable": "0.1.8",
         "readme-badges": "0.3.3",
@@ -7850,6 +8463,18 @@
             "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
           }
         },
+        "get-value": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "lazy-cache": "0.2.7",
+            "noncharacters": "1.1.0"
+          }
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -7875,6 +8500,12 @@
             "object-assign": "3.0.0"
           }
         },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -7888,21 +8519,6 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-              }
-            }
           }
         },
         "object-assign": {
@@ -7945,7 +8561,7 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
+        "clone": "1.0.4",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
@@ -7956,13 +8572,13 @@
       "integrity": "sha1-0VdS5owtrXQ2Tn6FNHNzU1RpLt8=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.0",
+        "duplexify": "3.5.4",
         "glob-stream": "4.1.1",
         "glob-watcher": "0.0.8",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+        "graceful-fs": "3.0.11",
         "merge-stream": "0.1.8",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+        "object-assign": "2.1.1",
         "strip-bom": "1.0.0",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
@@ -7973,6 +8589,33 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "dev": true,
+          "requires": {
+            "natives": "1.1.3"
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "strip-bom": {
           "version": "1.0.0",
@@ -7990,7 +8633,7 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
+            "readable-stream": "1.0.34",
             "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -40,7 +40,7 @@
       "dev": true,
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -79,9 +79,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-gray": {
@@ -634,6 +634,12 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1199,7 +1205,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
         "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
         "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
@@ -1458,32 +1464,32 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.0.tgz",
-      "integrity": "sha512-Ep2lUbztzXLg0gNUl48I1xvbQFy1QuWyh1C9PSympmln33jwOr8B3QfuEcXpPPE4uSwEzDaWhUxBN0sNQkzrBg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.4.0",
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.3",
-        "esquery": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-        "globals": "11.3.0",
+        "globals": "11.4.0",
         "ignore": "3.3.7",
         "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.5",
@@ -1494,6 +1500,7 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
+        "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
@@ -1534,11 +1541,12 @@
           }
         },
         "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.3",
             "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
@@ -1566,9 +1574,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
             "argparse": "1.0.10",
@@ -1686,7 +1694,7 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
+        "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
       }
     },
@@ -1697,12 +1705,12 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1713,22 +1721,21 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -1843,9 +1850,9 @@
       }
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1930,9 +1937,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-diff": {
@@ -3355,9 +3362,9 @@
       }
     },
     "globals": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+      "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
       "dev": true
     },
     "globby": {
@@ -3563,7 +3570,7 @@
       "dev": true,
       "requires": {
         "chalk": "2.4.0",
-        "eslint": "4.18.0"
+        "eslint": "4.19.1"
       }
     },
     "grunt-known-options": {
@@ -4248,11 +4255,11 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "chalk": "2.4.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
+        "external-editor": "2.2.0",
         "figures": "2.0.0",
         "lodash": "4.17.5",
         "mute-stream": "0.0.7",
@@ -4578,9 +4585,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -6475,6 +6482,12 @@
         "is-equal-shallow": "0.1.3",
         "is-primitive": "2.0.0"
       }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
     },
     "relative": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -688,32 +688,27 @@
       }
     },
     "chalk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-      "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "supports-color": "5.2.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha1-sNUzOxGE3TZmy+WqC0XFrHrBeko=",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -845,9 +840,9 @@
       }
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1470,7 +1465,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.1",
+        "chalk": "2.4.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -3567,7 +3562,7 @@
       "integrity": "sha512-VZlDOLrB2KKefDDcx/wR8rEEz7smDwDKVblmooa+itdt/2jWw3ee2AiZB5Ap4s4AoRY0pbHRjZ3HHwY8uKR9Rw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.1",
+        "chalk": "2.4.0",
         "eslint": "4.18.0"
       }
     },
@@ -3805,6 +3800,11 @@
           }
         }
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-glob": {
       "version": "0.1.1",
@@ -4249,7 +4249,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.1",
+        "chalk": "2.4.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -5354,7 +5354,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "2.3.1"
+        "chalk": "2.4.0"
       }
     },
     "logging-helpers": {
@@ -7160,7 +7160,7 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.1",
+        "chalk": "2.4.0",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^4.18.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jsdoc": "^3.4.1",
-    "eslint-plugin-node": "^6.0.0",
+    "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^2.6.0",
     "grunt": "^1.0.2",
     "grunt-eslint": "^20.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-jsdoc": "^3.4.1",
+    "eslint-plugin-jsdoc": "^3.6.3",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^2.6.0",
     "grunt": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "grunt-eslint": "^20.1.0",
     "grunt-release-it": "^1.0.1",
     "load-grunt-tasks": "^3.5.2",
-    "prettier": "^1.10.2",
+    "prettier": "^1.12.1",
     "verb": "^0.8.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "^2.3.1",
+    "chalk": "^2.4.0",
     "checkstyle-formatter": "^1.1.0",
     "crlf": "^1.1.0",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "verbalize": "^0.2.0"
   },
   "devDependencies": {
-    "eslint": "^4.18.0",
+    "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jsdoc": "^3.4.1",
     "eslint-plugin-node": "^6.0.1",


### PR DESCRIPTION
- eslint-plugin-node@6.0.1
- chalk@2.4.0
- eslint@4.19.1
- eslint-plugin-jsdoc@3.6.3
- prettier@1.12.1
- Reinstall verb@latest to update moment to safe version