### PR TITLE
Chore npm updates 20180520

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,9 +703,9 @@
       }
     },
     "chalk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1758,7 +1758,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -3571,7 +3571,7 @@
       "integrity": "sha512-VZlDOLrB2KKefDDcx/wR8rEEz7smDwDKVblmooa+itdt/2jWw3ee2AiZB5Ap4s4AoRY0pbHRjZ3HHwY8uKR9Rw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "eslint": "4.19.1"
       }
     },
@@ -4337,7 +4337,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
@@ -5138,7 +5138,7 @@
     "load-grunt-tasks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-4.0.0.tgz",
-      "integrity": "sha512-w5JYPHpZgMxu9XFR9N9MEzyX8E0mLhQkwQ1qVP4mb3gmuomw8Ww8J49NHMbXqyQliq2LUCqdU7/wW96IVuPCKw==",
+      "integrity": "sha1-9JS8D6xJURW1yMbJV8Xx8P/X7s4=",
       "dev": true,
       "requires": {
         "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -5517,7 +5517,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "2.4.0"
+        "chalk": "2.4.1"
       }
     },
     "logging-helpers": {
@@ -6267,7 +6267,7 @@
     "p-limit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
       "dev": true,
       "requires": {
         "p-try": "1.0.0"
@@ -7760,7 +7760,7 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,9 +1908,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.6.3.tgz",
-      "integrity": "sha512-99SddzRNkyQFhx8Du8M3ex/jG0MmuNu01gIb4iN+nNswYy8bKrwHnRRRQOcsBMFBIUArKAdU6BSI9OeLhYZl1w==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.7.0.tgz",
+      "integrity": "sha512-y8v3NRYhfEMHcaKPV3RK/JIMYW0k4cnUc3cNNHCwEXlB5gjyhkxqOfe8BRMgulYqzW0Y6a1q7YqqA9Cy07KNww==",
       "dev": true,
       "requires": {
         "comment-parser": "0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1779,7 +1779,7 @@
         "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "natural-compare": "1.4.0",
@@ -1915,7 +1915,7 @@
       "requires": {
         "comment-parser": "0.4.2",
         "jsdoctypeparser": "2.0.0-alpha-8",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "jsdoctypeparser": {
@@ -4342,7 +4342,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -5283,9 +5283,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -7761,7 +7761,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.4.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "^2.4.0",
+    "chalk": "^2.4.1",
     "checkstyle-formatter": "^1.1.0",
     "crlf": "^1.1.0",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "checkstyle-formatter": "^1.1.0",
     "crlf": "^1.1.0",
     "glob": "^7.1.2",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "log-symbols": "^2.2.0",
     "minimist": "^1.2.0",
     "path-is-absolute": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-jsdoc": "^3.6.3",
+    "eslint-plugin-jsdoc": "^3.7.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^2.6.0",
     "grunt": "^1.0.2",


### PR DESCRIPTION
- chalk@2.4.1
- lodash@4.17.10
- eslint-plugin-jsdoc@3.7.0