### PR TITLE
Gk ignore eslint plugin node

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,10 @@
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^1.17.1",
     "snyk": "^1.166.1"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "eslint-plugin-node"
+    ]
   }
 }


### PR DESCRIPTION
- Ignore eslint-plugin-node from greenkeeper updates